### PR TITLE
Add IndianaMap (US)

### DIFF
--- a/WME_OpenMaps.user.js
+++ b/WME_OpenMaps.user.js
@@ -30,6 +30,7 @@
 // @connect     imagery.nationalmap.gov
 // @connect     service.pdok.nl
 // @connect     geoportal.dgu.hr
+// @connect     di-ingov.img.arcgis.com
 // @connect     *
 // @icon        data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADcAAAA3CAMAAACfBSJ0AAABuVBMVEVHcEwOdZgIbZYNcpUPdJgJcZcLcZYXb5UOcJcOc5oNcpcOdZoPdZkLcpcKcJYLbpRHnKkrhKMohaIRcJQTbpEYtdYHg5Cl2sBrxpqJwMcvuXaT17VUu4k4uHsPcZoHgq4gomWZ17is3MVq0KFJvISe2Lw0vnqA06pEw4UjttdVyZGM1bKG1K4tsXJXwo1hxZRh0Zo6x4Ijq2k7wIBX0JRFtskLfqwNiJRBuoALipt6yqN0x6BOwolKx4px0KAJhaYVnrUMdqK13stSwb59vsmS0rMIg5o1tHUcjZovwapByohfypcxuNa/4tMfq8aCzKhNzY07uNFErLwqq24RlaqUy8Rfv5GMz64vtc05obEalIwlmKk2mqnL6dovk6AZoHYat8pVn68NkKN40aYlsZJos79fq7N+vMN1tbqTx9AZj6GAyL0pqoBGkKsTiLI8q4u31tg1q78no7ghurhexrVzv8VWpLtpq7iizsqlydeaydpxtccvhKMWf4QXmYEtv52IycRln7N0xbQUfpI0wo9Dwbl7rL9LorKu0dJOyaCDzK9jvLUVmJobo6Ygd5pVsKgonpEUe6SJu7z3kfFBAAAAE3RSTlMAwj7t2TFmBxIgp0+aeou4/vTT3cYvbAAABk5JREFUSMeNlvk/Yl0YwKU9KdxbKiUjE7JHpUFJiiTbiIQWZZkWoVLz2veMdfzF73POvRpmmPG9fW798Hx7nuece+45JSVvwuVyeXw+nwff3JIPAgZHWFW5j/jJYojKeB9ReezyqsCafGt5eQvxXZ5LVgrK+P9QeaXCZC6/vOzxLH9/plCQX1Vx+H/TSoUVG4WtQsED2f4r8n15OR+u4vDebay8Kpf3bG2B5SnkvxX5Dtk9T0lB6dsaX1DxlC9AzPJQ3it/xlvID3k88PGeVHHe0tiM8JNc/u2b3OuVrxc1eR6cIUz+slL0Rmusk8vL4eH19bx3HTFMsX5cT1n1Q/X1T5XCP7JhbW9jY2N9HT7Dx17K83rrX/D0e0YeI3x5ube3kQNxL7uXrYYgbxbsavSr+pnPG5Xlrzxh8iS3t5rL5VYRx9X1IBwff6aCqTvmU471clQ5lScnq7m1NfA2sqvx6ur4MYr8FY5xfHI4npIM3ouhTJ7s7q4BufhpdjXr9WaPqXh00RLF/Ml++a/53g/v7obD4bW11Xh8NZ6NZx10dM2nGoBWHPPz8z82ksVK2SzwQHu42l07jcdr4vE4Dke01LQg5jGT85Onu8l7EZdOd5/cvaqouLranblxOH4zWlpbWhGTFF/6wvssNvV8se6ToIF4enNT42hxUNFUeGtja2PjZCPlIPrW9gkOTlhG3CcXlioqFh4c8z+A1qIACiLSGIlQDkIWIBhoUXGFxP3SUmBpaeHL/I8bg/30FMXasZDJRDIRwNKHrj5ZnwxIkQQqlMckfy4GkPdwM2MwTGfsINqnDfZIJGPXRDIWoM9ikVHMyeZSZ7hQNkEaY4FA4AHVcWM32O2nGo3dbp+2WzSGjEWDkGlksg645gAleAKYew5BqJ2jgYc+3EIGCXaURKOxWOwXIHXKOt1udweAtd6Uk2CBJyJq1VL/HN10Znx8enzcgLNoOi8MnQhKa0coe1WPVv8Zv4QrIGxqaUpG9WyRXYz7fOPNvovrThp3T4/OrdPpsAVawmT0n7FLuAzw/Mq5Dtx2h8x9ce2+8Pl8F5TVA+h0UzpdP6KhV6VKONVnZ6UlXBZhsz5C4e1zqAV3BxTl1l1f9xSZmpoaGBgACVmqkTa/upYow95sCmlQB4g6RI+O8lyua8oaaGpq6u5W3SVGRkYSK8/eonJO2a4Er7+9H2lTuqm0C4QplyTtch25XOcgdWu10cHbRNtIW+wMeWLkAdB0e38/1IP+fsoVGgNvDKx0SCIJHZ1rtVrV4Ozs7WHQb8XjAuNpTSFRiVvH2sDYWDo9hunqAk8iOQLtbnB2xew/dBrRPJSUw/w9gtWgbAD6mxAQnw6dY6vrCGmStFYRHcRe0Gw8ZPLRciDUoylaa2ii6TqXuLq6ippEEqU96aH/NojeMXx4Pq3+3oZnsAWkQ+juojVJGrzZWbMpGDSbDtCK5zFIeGCk/scUTFBvU283Rdd5+ujchXuTNDc3T0xEo1FIZ5IG9QcwnOg1AQ06pSbzSqoX0U2b2vNQKB2itWbfxMTdHSpTajo8YOIXBVpIVqnUvIJEFYgqNFcUaWyNwzM7sbOD25OqbaQQv0J5YigUJ0yoaGhLcURZ49M+3/b2zuJszCR1GglcJn7BECihyUx7WoVKoVUA0RDWpqenDQbkxUZNTkjHoPdsPoNEHUrN/hGMYkSheKUZDIaZme0F5FkhXXH75BB4SKXmBC0q2uCKhqBKH6WBt7C0CNpmLSkuHhF4AhJXKvWPtBVJTCBgJVIaeIHR0c2fJLPs5a4JlSLx67Olb4tib2J7ewZDaUaSeLXlcpiU+JVCr2/TJwaBnZ2dbWQuIC22uUmQjNfHERGBRdpCBO9ocQGkpQDWSJLeG34hQKLar6/T0wRhsSVuZxcxUGNs00iQzD/PMCDC4ATrAJDrguaVQ33wdiUWi40iNmFI3tJgj2eSpM1cR+OER19/aDZhzNZNYy1JsN4+MXFYJEkcUFoQBjeIblKp02lVG22QTPze2Y4tgJRYPLQ6nU6kOK1WNbZIVvn7Z0kuR0yQB4DNaFQjjEajzUZAGUwh+68HUD5HwCQgkCRqMfgnwRKV/vPMyy8tF4OKZRJ9s4Qc9ocO2Vw+u4wjEogZYrFAxCnl80o+DpznMe8l+h9u1SIwib9KHQAAAABJRU5ErkJggg==
 // @supportURL  https://github.com/Glodenox/wme-om/issues
@@ -191,7 +192,8 @@ async function onWmeReady() {
         v3_2_18: '- Fix Brussels Ortho map location (BE)',
         v3_2_19: '- Prepare for changes in WME beta',
         v3_2_20: '- Fix map retrieval breakage due to unexpected changes',
-        v3_2_21: '- Fix WV Leaves off and USGS NAIP+ layers (US)'
+        v3_2_21: '- Fix WV Leaves off and USGS NAIP+ layers (US)',
+        v3_2_22: '- Added IndianaMap (US)'
       }
     },
     nl: {
@@ -335,7 +337,8 @@ async function onWmeReady() {
         v3_2_18: '- Herstel Brussels Ortho kaart (BE)',
         v3_2_19: '- Voorbereiding voor wijzigingen in WME beta',
         v3_2_20: '- Fix map retrieval breakage due to unexpected changes',
-        v3_2_21: '- Fix WV Leaves off and USGS NAIP+ layers (US)'
+        v3_2_21: '- Fix WV Leaves off and USGS NAIP+ layers (US)',
+        v3_2_22: '- Added IndianaMap (US)'
       }
     },
     fr: {
@@ -1197,6 +1200,27 @@ async function onWmeReady() {
           queryable: false,
           title: 'Orthoimagery_Latest',
           abstract: 'Imagery/Orthoimagery_Latest'
+        }
+      }
+    },
+    {
+      id: 115,
+      title: 'IndianaMap',
+      type: 'WMS',
+      url: 'https://di-ingov.img.arcgis.com/arcgis/services/DynamicWebMercator/Indiana_Current_Imagery/ImageServer/WMSServer',
+      crs: 'EPSG:3857',
+      bbox: [-88.165560, 37.762766, -84.698567, 41.813054],
+      format: 'image/png',
+      area: 'US',
+      abstract: 'State of Indiana Current Orthophotography',
+      attribution: 'IndianaMap', // https://www.indianamap.org/pages/faqs-and-guides
+      queryable: false,
+      default_layers: ['Indiana_Current_Imagery:None'],
+      layers: {
+        'Indiana_Current_Imagery:None': {
+          queryable: false,
+          title: 'Indiana_Current_Imagery',
+          abstract: 'Indiana_Current_Imagery'
         }
       }
     },


### PR DESCRIPTION
IndianaMap imagery is available for public use.

From IndianaMap:
Can I use web services in my own maps, projects, and software?
All IndianaMap datasets, including aerial photography, are available for public use in any application. If you do not want to download a layer as a local file, you are able to add data to a variety of different applications by the URL. To obtain the feature service URL, navigate to the "I Want to Use This" button on the item overview. You can then either copy the URL for easy copy-and-pasting into your application, or can open the API explorer to set filters and select a list of attributes to include for your purposes. (https://www.indianamap.org/pages/faqs-and-guides)

From the Indiana Imagery Program:
State-collected imagery is available for public use through web map applications, including the IndianaMap. It is available via web service or download. (https://imagery.gio.in.gov/)